### PR TITLE
New counter must not be equal (or less)

### DIFF
--- a/src/main/java/com/mastercard/ess/fido2/service/CommonVerifiers.java
+++ b/src/main/java/com/mastercard/ess/fido2/service/CommonVerifiers.java
@@ -116,8 +116,8 @@ class CommonVerifiers {
         }
     }
 
-    void verifyCounter(int counter, int oldCounter) {
-        if(oldCounter < counter) {
+    void verifyCounter(int oldCounter, int newCounter) {
+        if(newCounter <= oldCounter) {
             throw new RuntimeException("Counter did not increase");
         }
 


### PR DESCRIPTION
Fail when the new counter is less than **or equal to** the old value, not just when it is less than.

The argument names are also misleading.